### PR TITLE
end-end icap client-server test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/egirna/icap
+module github.com/Cequence-Security/icap
 
 go 1.17

--- a/request.go
+++ b/request.go
@@ -146,7 +146,7 @@ func ReadRequest(b *bufio.ReadWriter) (req *Request, err error) {
 		if p := req.Header.Get("Preview"); p != "" {
 			moreBody := false
 			
-			if previewSize, err := strconv.Atoi(p); err != nil && previewSize > 0 {
+			if previewSize, err := strconv.Atoi(p); err == nil && previewSize > 0 {
 				moreBody = true
 			}
 			

--- a/response.go
+++ b/response.go
@@ -182,7 +182,7 @@ func httpRequestHeader(req *http.Request) (hdr []byte, err error) {
 	fmt.Fprintf(buf, "%s %s %s\r\n", valueOrDefault(req.Method, "GET"), uri, valueOrDefault(req.Proto, "HTTP/1.1"))
 	req.Header.WriteSubset(buf, map[string]bool{
 		"Transfer-Encoding": true,
-		"Content-Length":    true,
+		"Content-Length":    false,
 	})
 	io.WriteString(buf, "\r\n")
 


### PR DESCRIPTION
- module name; 
- read beyond preview correctly; 
- Excluding content-length header can impact upstream content reading;